### PR TITLE
Fix/17 test no working

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20.x
           cache: 'yarn'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,5 +45,5 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: integration_test
         env:
-          ALCHEMY_RPC_ENDPOINT: ${{ vars.ALCHEMY_RPC_ENDPOINT }}
+          ALCHEMY_RPC_ENDPOINT: ${{ secrets.ALCHEMY_RPC_ENDPOINT }}
         run: yarn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,4 +44,6 @@ jobs:
           path: '**/node_modules'
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: integration_test
+        env:
+          ALCHEMY_RPC_ENDPOINT: ${{ secrets.ALCHEMY_RPC_ENDPOINT }}
         run: yarn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,5 +45,5 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: integration_test
         env:
-          ALCHEMY_RPC_ENDPOINT: ${{ secrets.ALCHEMY_RPC_ENDPOINT }}
+          ALCHEMY_RPC_ENDPOINT: ${{ vars.ALCHEMY_RPC_ENDPOINT }}
         run: yarn test

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -1,4 +1,5 @@
 import { AddressZero } from '@ethersproject/constants';
+import nextEnv from '@next/env';
 import { ThirdwebSDK } from '@thirdweb-dev/sdk';
 import assert from 'assert';
 import ethers from 'ethers';
@@ -12,16 +13,22 @@ import {
 } from '../scripts/module';
 
 describe('ETH-DAO test', function () {
+  // 環境変数を env ファイルから読み込む
+  const { loadEnvConfig } = nextEnv;
+  const { ALCHEMY_RPC_ENDPOINT } = loadEnvConfig(process.cwd()).combinedEnv;
+
+  // ALCHEMY_RPC_ENDPOINTが取得できなかった場合、エラーを出力して終了
+  if (!ALCHEMY_RPC_ENDPOINT || ALCHEMY_RPC_ENDPOINT === '') {
+    throw new Error('🛑 Alchemy RPC Endpoint not found.');
+  }
+
   // テスト用のウォレットを作成
   const demoWallet = ethers.Wallet.createRandom();
-  // テスト用のPublic RPC Endpointを設定
-  // 参照：https://docs.alchemy.com/docs/choosing-a-web3-network#sepolia-testnet
-  const demoAlchemyRPCEndpoint = 'https://eth-sepolia.g.alchemy.com/v2/demo';
 
   const sdk = new ThirdwebSDK(
     new ethers.Wallet(
       demoWallet.privateKey,
-      ethers.getDefaultProvider(demoAlchemyRPCEndpoint),
+      ethers.getDefaultProvider(ALCHEMY_RPC_ENDPOINT),
     ),
   );
 


### PR DESCRIPTION
## 変更内容
テストスクリプト内で使用するRPC Endpointを、publicのものからUNCHAINのAlchemy api keyに変更しました。

## 背景
これまで使用していたhttps://eth-sepolia.g.alchemy.com/v2/demo が使用できなくなっており、テストが実行されなくなってしまったためです。

## 備考
CIでテストスクリプトを動作させるために、Repository variablesを設定しました。

![Screenshot 2023-11-17 at 16 48 53](https://github.com/unchain-tech/ETH-DAO/assets/60546319/40f3b9e4-fa95-49e2-8e9e-1cbb71971c1e)
